### PR TITLE
fix: 彻底修复按钮在聊天列表显示导致遮挡头像的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 一个功能强大的油猴脚本，用于下载 Telegram Web 中的受限图片和视频，支持最佳质量下载。
 
-![版本](https://img.shields.io/badge/version-1.3.2-blue.svg)
+![版本](https://img.shields.io/badge/version-1.3.3-blue.svg)
 ![许可证](https://img.shields.io/badge/license-MIT-green.svg)
 ![平台](https://img.shields.io/badge/platform-Telegram%20Web-blue.svg)
 
@@ -230,6 +230,15 @@ Telegram/telegram_video_1704067200000.mp4
 - 💡 原因：某些视频使用特殊编码（H.265/HEVC）浏览器不支持
 
 ## 🚀 更新日志
+
+### v1.3.3 (2025-12-31)
+- 🐛 **修复按钮在聊天列表显示的问题**（彻底解决遮挡头像）
+- 🚫 添加聊天列表和侧边栏检测，完全排除这些区域
+- ✅ 只在真正的媒体内容上显示下载按钮
+- 🎯 新增 isInChatListOrSidebar 检测聊天列表
+- 🎯 新增 isActualMediaContent 检测真实媒体内容
+- 📍 排除头像、个人资料图片等非媒体图片
+- 🔍 更精确的容器检测（MediaViewer、MessageMedia 等）
 
 ### v1.3.2 (2025-12-31)
 - 🎨 **优化下载按钮位置**（解决遮挡问题）


### PR DESCRIPTION
解决用户反馈的按钮在聊天列表和其他非媒体区域显示的问题：

🐛 问题根源:
- 脚本在聊天列表的头像图片上也添加了下载按钮
- 按钮出现在侧边栏、个人资料等非媒体区域
- 导致遮挡头像和其他重要UI元素

✅ 解决方案:

1. 新增 isInChatListOrSidebar 函数:
   - 检测聊天列表 (.chat-list, [class*="ChatList"])
   - 检测左侧栏 (.left-column, [class*="LeftColumn"])
   - 检测侧边栏 (.sidebar, [class*="Sidebar"])
   - 检测对话列表 (.dialogs, [class*="Dialog"])
   - 完全排除这些区域的所有图片

2. 新增 isActualMediaContent 函数:
   - 验证元素是否在媒体查看器中
   - 验证元素是否在消息媒体容器中
   - 验证元素是否在相册、附件等媒体容器中
   - 只有真正的媒体内容才显示按钮

3. 增强 hasAvatarOrImportantElement 函数:
   - 新增 sender-photo、SenderPhoto 检测
   - 检查容器本身是否是头像
   - 检查容器类名是否包含 avatar/Avatar/profile

4. processMediaElement 改进:
   - 优先检查是否在聊天列表（立即返回）
   - 检查是否是真实媒体内容
   - 排除头像图片本身
   - 三层防护确保不误判

🎯 显示范围:
✅ 允许:
- 媒体查看器中的图片/视频
- 消息中的媒体附件
- 相册中的媒体
- 附件中的图片/视频

🚫 禁止:
- 聊天列表中的头像
- 侧边栏中的图片
- 个人资料图片
- 对话列表中的缩略图
- 任何非媒体内容的图片

📊 技术实现:
- 使用 closest() 检测父级容器
- 多个选择器覆盖 Telegram 的各种类名
- 优先级检查：聊天列表 > 媒体内容 > 头像
- 性能优化：早期返回避免不必要的处理

现在下载按钮只会出现在真正的媒体内容上，
不会再遮挡聊天列表的头像或其他UI元素！

版本: v1.3.3