### PR TITLE
feat: 移除视频截图功能，仅下载视频文件 (v1.3.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 一个功能强大的油猴脚本，用于下载 Telegram Web 中的受限图片和视频，支持最佳质量下载。
 
-![版本](https://img.shields.io/badge/version-1.3.3-blue.svg)
+![版本](https://img.shields.io/badge/version-1.3.4-blue.svg)
 ![许可证](https://img.shields.io/badge/license-MIT-green.svg)
 ![平台](https://img.shields.io/badge/platform-Telegram%20Web-blue.svg)
 
@@ -230,6 +230,14 @@ Telegram/telegram_video_1704067200000.mp4
 - 💡 原因：某些视频使用特殊编码（H.265/HEVC）浏览器不支持
 
 ## 🚀 更新日志
+
+### v1.3.4 (2025-12-31)
+- 🎯 **移除视频截图功能**（按用户要求）
+- ❌ 下载视频时不再截取视频帧作为图片
+- 💡 对于无法直接下载的视频，提供清晰的错误提示
+- 📖 引导用户使用 Telegram Desktop 或手机端下载视频
+- ✅ 保留图片的 Canvas 捕获功能
+- 🔍 更准确的错误信息（说明无法下载的原因）
 
 ### v1.3.3 (2025-12-31)
 - 🐛 **修复按钮在聊天列表显示的问题**（彻底解决遮挡头像）

--- a/telegram-media-downloader.user.js
+++ b/telegram-media-downloader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Telegram 受限媒体下载器
 // @namespace    https://github.com/weiruankeji2025/weiruan-Telegram
-// @version      1.3.3
+// @version      1.3.4
 // @description  下载 Telegram Web 中的受限图片和视频，支持最佳质量下载
 // @author       WeiRuan Tech
 // @match        https://web.telegram.org/*
@@ -678,10 +678,10 @@
 
             // 检查是否是 Telegram 内部 URL
             if (isTelegramInternalUrl(url)) {
-                notify('检测到受限内容', '正在使用高级捕获技术...', 'info');
-
                 // 对于图片，使用 Canvas 捕获
                 if (mediaType === 'image' && sourceElement && sourceElement.tagName === 'IMG') {
+                    notify('检测到受限内容', '正在使用高级捕获技术...', 'info');
+
                     // 等待图片完全加载
                     if (!sourceElement.complete) {
                         await new Promise((resolve, reject) => {
@@ -693,29 +693,9 @@
 
                     blobUrl = await captureImageWithCanvas(sourceElement);
                 }
-                // 对于视频，捕获当前帧（作为图片）
-                else if (mediaType === 'video' && sourceElement && sourceElement.tagName === 'VIDEO') {
-                    // 先检查视频是否可以捕获
-                    if (!canCaptureVideo(sourceElement)) {
-                        throw new Error('❌ 此视频无法下载\n\n💡 这可能是因为：\n• 视频使用了特殊编码（H.265/HEVC）浏览器不支持\n• Telegram Web 限制了此视频的播放\n\n✅ 请点击页面上的【查看下载方法】按钮，获取完整下载指南！\n\n或使用以下方法：\n1️⃣ Telegram Desktop（推荐）\n2️⃣ 手机 Telegram\n3️⃣ 屏幕录制工具');
-                    }
-
-                    try {
-                        notify('视频截图', '正在捕获视频画面...', 'info');
-                        blobUrl = await captureVideoFrame(sourceElement);
-                        // 修改文件名为图片格式
-                        filename = filename.replace(/\.(mp4|webm)$/, '.png');
-                        notify('截图成功', '将保存为PNG图片', 'success');
-                    } catch (videoError) {
-                        console.error('视频捕获失败:', videoError);
-
-                        // 检查是否是超时错误
-                        if (videoError.message.includes('超时') || videoError.message.includes('timeout')) {
-                            throw new Error('❌ 视频加载超时\n\n💡 此视频可能无法在 Telegram Web 上播放\n\n✅ 请查找页面上的【查看下载方法】按钮（粉红色），点击查看完整下载指南！\n\n推荐方案：\n• 使用 Telegram Desktop（最简单）\n• 或在手机 Telegram 中下载');
-                        }
-
-                        throw new Error(`❌ 视频处理失败\n\n原因：${videoError.message}\n\n✅ 请使用页面上的【查看下载方法】按钮获取其他下载方案`);
-                    }
+                // 对于视频，不截图，直接提示用户
+                else if (mediaType === 'video') {
+                    throw new Error('❌ 此视频无法直接下载\n\n💡 原因：\n• 视频使用了 Telegram 内部 URL 格式\n• Service Worker 保护导致无法直接访问\n• 浏览器可能不支持该视频编码格式\n\n✅ 请使用以下方法下载：\n\n1️⃣ Telegram Desktop（推荐）\n   • 打开同一条消息\n   • 右键视频 → 另存为\n   • 支持所有视频格式\n\n2️⃣ 手机 Telegram\n   • 在手机上打开消息\n   • 下载后传输到电脑\n\n3️⃣ 查找粉红色【查看下载方法】按钮\n   • 如果看到"视频无法播放"提示\n   • 点击按钮查看详细指南');
                 }
                 else {
                     throw new Error('无法处理此类型的受限内容');
@@ -766,7 +746,7 @@
                 }
             }, 100);
 
-            notify('下载完成', `${mediaType === 'video' ? '图片' : '图片'}已保存！`, 'success');
+            notify('下载完成', `${mediaType === 'video' ? '视频' : '图片'}已保存！`, 'success');
         } catch (error) {
             console.error('备用下载错误:', error);
             throw new Error(`备用下载失败: ${error.message}`);
@@ -1156,7 +1136,7 @@
     function addWatermark() {
         const watermark = document.createElement('div');
         watermark.className = 'tg-watermark';
-        watermark.textContent = 'Telegram 下载器 v1.3.3';
+        watermark.textContent = 'Telegram 下载器 v1.3.4';
         document.body.appendChild(watermark);
 
         // 5秒后隐藏水印


### PR DESCRIPTION
按用户要求修改视频下载逻辑：
- 移除视频帧截图功能
- 对于无法直接下载的视频，显示详细错误提示
- 引导用户使用 Telegram Desktop 或手机端下载
- 保留图片的 Canvas 捕获功能
- 更新版本号至 1.3.4

变更文件：
- telegram-media-downloader.user.js: 修改 fallbackDownload() 函数
- README.md: 更新版本号和更新日志