### PR TITLE
feat: 添加按钮位置设置功能 (v1.5.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 一个功能强大的油猴脚本，用于下载 Telegram Web 中的受限图片和视频，支持最佳质量下载。
 
-![版本](https://img.shields.io/badge/version-1.5.2-blue.svg)
+![版本](https://img.shields.io/badge/version-1.5.3-blue.svg)
 ![许可证](https://img.shields.io/badge/license-MIT-green.svg)
 ![平台](https://img.shields.io/badge/platform-Telegram%20Web-blue.svg)
 
@@ -230,6 +230,14 @@ Telegram/telegram_video_1704067200000.mp4
 - 💡 原因：某些视频使用特殊编码（H.265/HEVC）浏览器不支持
 
 ## 🚀 更新日志
+
+### v1.5.3 (2025-12-31)
+- 📍 **添加按钮位置设置** - 解决按钮被字幕遮挡的问题
+- ⚙️ **4个位置可选** - 右上角、左上角、右下角、左下角
+- 🎛️ **脚本菜单设置** - 点击Tampermonkey图标 → 脚本菜单 → 选择位置
+- 💾 **自动保存配置** - 设置后自动保存，刷新页面生效
+- 🎯 **默认右上角** - 首次使用默认在右上角
+- 📝 **控制台提示** - 启动时显示当前按钮位置配置
 
 ### v1.5.2 (2025-12-31)
 - 🎉 **重大重构：精简代码，提高性能**

--- a/telegram-media-downloader.user.js
+++ b/telegram-media-downloader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Telegram 受限媒体下载器
 // @namespace    https://github.com/weiruankeji2025/weiruan-Telegram
-// @version      1.5.2
+// @version      1.5.3
 // @description  下载 Telegram Web 中的受限图片和视频
 // @author       WeiRuan Tech
 // @match        https://web.telegram.org/*
@@ -23,7 +23,15 @@
     const CONFIG = {
         downloadPath: GM_getValue('downloadPath', 'Telegram'),
         notifyOnDownload: GM_getValue('notifyOnDownload', true),
+        buttonPosition: GM_getValue('buttonPosition', 'top-right'), // top-right, top-left, bottom-right, bottom-left
     };
+
+    // 保存配置
+    function saveConfig() {
+        GM_setValue('downloadPath', CONFIG.downloadPath);
+        GM_setValue('notifyOnDownload', CONFIG.notifyOnDownload);
+        GM_setValue('buttonPosition', CONFIG.buttonPosition);
+    }
 
     // Content-Range 正则
     const contentRangeRegex = /^bytes (\d+)-(\d+)\/(\d+)$/;
@@ -358,7 +366,16 @@
             <span>下载${mediaType === 'video' ? '视频' : '图片'}</span>
         `;
 
-        button.style.cssText = 'position:absolute;top:10px;right:10px;padding:8px 16px;background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);color:white;border:none;border-radius:20px;cursor:pointer;font-size:14px;font-weight:bold;display:flex;align-items:center;gap:8px;box-shadow:0 4px 6px rgba(0,0,0,0.1);z-index:1000;opacity:0.9;transition:all 0.3s;';
+        // 根据配置设置按钮位置
+        const positions = {
+            'top-right': 'top:10px;right:10px;',
+            'top-left': 'top:10px;left:10px;',
+            'bottom-right': 'bottom:10px;right:10px;',
+            'bottom-left': 'bottom:10px;left:10px;'
+        };
+        const positionStyle = positions[CONFIG.buttonPosition] || positions['top-right'];
+
+        button.style.cssText = `position:absolute;${positionStyle}padding:8px 16px;background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);color:white;border:none;border-radius:20px;cursor:pointer;font-size:14px;font-weight:bold;display:flex;align-items:center;gap:8px;box-shadow:0 4px 6px rgba(0,0,0,0.1);z-index:1000;opacity:0.9;transition:all 0.3s;`;
 
         button.addEventListener('click', async (e) => {
             e.stopPropagation();
@@ -459,12 +476,41 @@
         document.body.appendChild(container);
     }
 
+    // 注册菜单命令
+    function registerMenuCommands() {
+        GM_registerMenuCommand('📍 按钮位置: 右上角', () => {
+            CONFIG.buttonPosition = 'top-right';
+            saveConfig();
+            alert('✅ 按钮位置已设置为：右上角\n\n刷新页面后生效');
+        });
+
+        GM_registerMenuCommand('📍 按钮位置: 左上角', () => {
+            CONFIG.buttonPosition = 'top-left';
+            saveConfig();
+            alert('✅ 按钮位置已设置为：左上角\n\n刷新页面后生效');
+        });
+
+        GM_registerMenuCommand('📍 按钮位置: 右下角', () => {
+            CONFIG.buttonPosition = 'bottom-right';
+            saveConfig();
+            alert('✅ 按钮位置已设置为：右下角\n\n刷新页面后生效');
+        });
+
+        GM_registerMenuCommand('📍 按钮位置: 左下角', () => {
+            CONFIG.buttonPosition = 'bottom-left';
+            saveConfig();
+            alert('✅ 按钮位置已设置为：左下角\n\n刷新页面后生效');
+        });
+    }
+
     // 初始化
     function init() {
         addStyles();
         setupProgressContainer();
         startObserving();
+        registerMenuCommands();
         console.log('[Telegram下载器] v1.5.2 已加载');
+        console.log('[配置] 按钮位置:', CONFIG.buttonPosition);
     }
 
     // 启动


### PR DESCRIPTION
解决问题：
- 按钮被视频字幕遮挡
- 用户无法调整按钮位置

新增功能：

1. 按钮位置配置
   - 支持4个位置：右上角、左上角、右下角、左下角
   - 默认位置：右上角
   - 配置自动保存到本地

2. 脚本菜单
   - 📍 按钮位置: 右上角
   - 📍 按钮位置: 左上角
   - 📍 按钮位置: 右下角
   - 📍 按钮位置: 左下角

3. 使用方法
   - 点击Tampermonkey图标
   - 选择"Telegram 受限媒体下载器"
   - 点击相应的菜单项
   - 刷新页面生效

技术实现：
- CONFIG.buttonPosition: 保存配置
- saveConfig(): 持久化配置
- positions对象: 位置CSS映射
- GM_registerMenuCommand: 注册菜单
- 动态生成按钮样式

变更文件：
- telegram-media-downloader.user.js: 添加配置和菜单
- README.md: 更新版本和说明